### PR TITLE
Add basic React Flow example project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# react-flow
+# React Flow Example
+
+This project demonstrates a minimal setup for [React Flow](https://reactflow.dev/).
+
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+Run tests (none defined yet):
+
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>React Flow Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "react-flow-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Simple React Flow example",
+  "scripts": {
+    "test": "echo \"No tests specified\" && exit 0",
+    "start": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "reactflow": "^11.7.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactFlow, { MiniMap, Controls, Background } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+const initialNodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: 'Start' } },
+  { id: '2', position: { x: 200, y: 100 }, data: { label: 'End' } }
+];
+
+const initialEdges = [
+  { id: 'e1-2', source: '1', target: '2' }
+];
+
+export default function App() {
+  return (
+    <div style={{ width: '100%', height: '100vh' }}>
+      <ReactFlow nodes={initialNodes} edges={initialEdges}>
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- scaffold minimal React Flow project with example nodes and edges
- configure package.json and development entry files
- document setup and usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899dacfbc2c8326b3a45b5a85dfb443